### PR TITLE
feat: speed up prepare for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ Uses
 
 If you want to test local changes in an actual deployment, use `npm link`.
 
+1. Make sure your npm uses the same version as the client directory.
 1. Run `npm run updatelink`.
-4. Go to client directory and run `npm link promoted-ts-client`.
+1. Go to client directory and run `npm link promoted-ts-client`.
 
 When you update `promoted-ts-client`, run `npm run updatelink`.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "npm run build:clean && npm run build:lib",
     "build:clean": "rimraf dist",
     "build:lib": "rollup -c",
-    "updatelink": "npm run build:clean && npm run build && cd dist && npm link",
+    "updatelink": "npm run build && cd dist && npm link",
     "unlink": "cd dist && npm unlink",
     "lint": "eslint './{src,app}/**/*.{ts,tsx}'",
     "test": "jest --coverage",

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1060,4 +1060,20 @@ describe('metrics', () => {
     expect(deliveryClient.mock.calls.length).toBe(0);
     expect(metricsClient.mock.calls.length).toBe(1);
   });
+
+  // TODO - add test where IDs are passed in.
+  describe('check input fields should be undefined', () => {
+    it('Request.requestId', async () => {
+      const promotedClient = newFakePromotedClient({});
+      await expect(
+        promotedClient.prepareForLogging({
+          request: {
+            ...newBaseRequest(),
+            requestId: 'uuid0',
+          },
+          fullInsertion: toInsertions([newProduct('3'), newProduct('2'), newProduct('1')]),
+        })
+      ).rejects.toEqual(new Error('Request.requestId should not be set'));
+    });
+  });
 });


### PR DESCRIPTION
On a dev setup, Node.js seems to add 0.25 milliseconds of latency for having an extra layer of async/await.