### PR TITLE
fix: No redundant userInfos under LogRequest;TESTING=unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ typings/
 
 .idea
 dist/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ There are two ways of doing this with `PromotedClient`:
 1. You can use `deliver` but add a `shouldOptimize: false` property.
 2. You can use `prepareForLogging` method call instead.  The `prepareForLogging` signature is similar to `deliver` and should be integrated the same way.
 
+## Pagination
+
+The `prepareForLogging` call assumes the client has already handled pagination.  It needs a `Request.paging.offset` to be passed in for the number of items deep that the page is.
+
 # Improving this library
 
 ## Tech used

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1452,7 +1452,7 @@ describe('metrics', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             paging: {
               size: 1,

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -110,7 +110,7 @@ describe('no-op', () => {
       await response.log();
     });
 
-    it('limit 1', async () => {
+    it('page size 1', async () => {
       const promotedClient = newFakePromotedClient({
         enabled: false,
         deliveryClient: jest.fn(failFunction('Delivery should not be called in CONTROL')),
@@ -120,7 +120,9 @@ describe('no-op', () => {
       const response = await promotedClient.deliver({
         request: {
           ...newBaseRequest(),
-          limit: 1,
+          paging: {
+            size: 1,
+          },
         },
         fullInsertion: toInsertions(products),
       });
@@ -147,7 +149,7 @@ describe('no-op', () => {
       await response.log();
     });
 
-    it('limit 1', async () => {
+    it('page size 1', async () => {
       const promotedClient = newFakePromotedClient({
         enabled: false,
         deliveryClient: jest.fn(failFunction('Delivery should not be called')),
@@ -157,7 +159,30 @@ describe('no-op', () => {
       const response = promotedClient.prepareForLogging({
         request: {
           ...newBaseRequest(),
-          limit: 1,
+          paging: {
+            size: 1,
+          },
+        },
+        fullInsertion: toInsertions(products),
+      });
+      expect(response.insertion).toEqual(toInsertions([newProduct('3')]));
+      await response.log();
+    });
+
+    it('non-zero offset', async () => {
+      const promotedClient = newFakePromotedClient({
+        enabled: false,
+        deliveryClient: jest.fn(failFunction('Delivery should not be called')),
+        metricsClient: jest.fn(failFunction('Metrics should not be called')),
+      });
+      const products = [newProduct('3'), newProduct('2'), newProduct('1')];
+      const response = promotedClient.prepareForLogging({
+        request: {
+          ...newBaseRequest(),
+          paging: {
+            size: 1,
+            offset: 1,
+          },
         },
         fullInsertion: toInsertions(products),
       });
@@ -775,7 +800,7 @@ describe('deliver', () => {
     });
   });
 
-  it('limit 1', async () => {
+  it('page size 1', async () => {
     const deliveryClient: any = jest.fn(failFunction('Delivery should not be called in CONTROL'));
     const metricsClient: any = jest.fn((request) => {
       expect(request).toEqual({
@@ -808,7 +833,9 @@ describe('deliver', () => {
           {
             ...newBaseRequest(),
             requestId: 'uuid0',
-            limit: 1,
+            paging: {
+              size: 1,
+            },
             timing: {
               clientLogTimestamp: 12345678,
             },
@@ -826,7 +853,9 @@ describe('deliver', () => {
     const response = await promotedClient.deliver({
       request: {
         ...newBaseRequest(),
-        limit: 1,
+        paging: {
+          size: 1,
+        },
       },
       fullInsertion: toInsertions(products),
       experiment: {
@@ -1393,7 +1422,7 @@ describe('metrics', () => {
     expect(metricsClient.mock.calls.length).toBe(1);
   });
 
-  it('limit 1', async () => {
+  it('page size 1', async () => {
     const deliveryClient: any = jest.fn(failFunction('Delivery should not be called in CONTROL'));
     const metricsClient: any = jest.fn((request) => {
       expect(request).toEqual({
@@ -1409,18 +1438,14 @@ describe('metrics', () => {
             requestId: 'uuid0',
             position: 0,
           }),
-          toInsertion(newProduct('2'), {
-            position: 1,
-          }),
-          toInsertion(newProduct('1'), {
-            position: 2,
-          }),
         ],
         request: [
           {
             ...newBaseRequest(),
             requestId: 'uuid0',
-            limit: 1,
+            paging: {
+              size: 1,
+            },
             timing: {
               clientLogTimestamp: 12345678,
             },
@@ -1438,7 +1463,73 @@ describe('metrics', () => {
     const response = promotedClient.prepareForLogging({
       request: {
         ...newBaseRequest(),
-        limit: 1,
+        paging: {
+          size: 1,
+        },
+      },
+      fullInsertion: toInsertions(products),
+    });
+    expect(deliveryClient.mock.calls.length).toBe(0);
+    expect(metricsClient.mock.calls.length).toBe(0);
+
+    expect(response.insertion).toEqual([
+      toInsertion(newProduct('3'), {
+        insertionId: 'uuid1',
+        requestId: 'uuid0',
+      }),
+    ]);
+    // Here is where clients will return their response.
+    await response.log();
+    expect(deliveryClient.mock.calls.length).toBe(0);
+    expect(metricsClient.mock.calls.length).toBe(1);
+  });
+
+  it('non-zero page offset', async () => {
+    const deliveryClient: any = jest.fn(failFunction('Delivery should not be called in CONTROL'));
+    const metricsClient: any = jest.fn((request) => {
+      expect(request).toEqual({
+        userInfo: {
+          logUserId: 'logUserId1',
+        },
+        timing: {
+          clientLogTimestamp: 12345678,
+        },
+        insertion: [
+          toInsertion(newProduct('3'), {
+            insertionId: 'uuid1',
+            requestId: 'uuid0',
+            position: 100,
+          }),
+        ],
+        request: [
+          {
+            ...newBaseRequest(),
+            requestId: 'uuid0',
+            paging: {
+              size: 1,
+              offset: 100,
+            },
+            timing: {
+              clientLogTimestamp: 12345678,
+            },
+          },
+        ],
+      });
+    });
+
+    const promotedClient = newFakePromotedClient({
+      deliveryClient,
+      metricsClient,
+    });
+
+    const products = [newProduct('3'), newProduct('2'), newProduct('1')];
+    const response = promotedClient.prepareForLogging({
+      request: {
+        ...newBaseRequest(),
+        paging: {
+          size: 1,
+          offset: 100,
+        },
       },
       fullInsertion: toInsertions(products),
     });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -50,6 +50,7 @@ const toInsertionOnlyContentId = (product: Product, extraFields: InsertionFields
   contentId: product.id.toString(),
 });
 
+// Creates a new request.
 const newBaseRequest = (): Partial<Request> => ({
   userInfo: {
     logUserId: 'logUserId1',
@@ -57,6 +58,16 @@ const newBaseRequest = (): Partial<Request> => ({
   useCase: 'FEED',
   // TODO - sessionId: .
   // TODO - viewId: .
+  properties: {
+    struct: {
+      query: 'fakequery',
+    },
+  },
+});
+
+// Creates a  new request passed through the LogRequest, for which the client will strip userInfo.
+const newLogRequestRequest = (): Partial<Request> => ({
+  useCase: 'FEED',
   properties: {
     struct: {
       query: 'fakequery',
@@ -278,7 +289,7 @@ describe('deliver', () => {
           ],
           request: [
             {
-              ...newBaseRequest(),
+              ...newLogRequestRequest(),
               requestId: 'uuid0',
               timing: {
                 clientLogTimestamp: 12345678,
@@ -510,7 +521,7 @@ describe('deliver', () => {
           ],
           request: [
             {
-              ...newBaseRequest(),
+              ...newLogRequestRequest(),
               requestId: 'uuid0',
               timing: {
                 clientLogTimestamp: 12345678,
@@ -595,7 +606,7 @@ describe('deliver', () => {
           ],
           request: [
             {
-              ...newBaseRequest(),
+              ...newLogRequestRequest(),
               requestId: 'uuid0',
               timing: {
                 clientLogTimestamp: 12345678,
@@ -831,7 +842,7 @@ describe('deliver', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             paging: {
               size: 1,
@@ -907,7 +918,7 @@ describe('deliver', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             timing: {
               clientLogTimestamp: 12345678,
@@ -994,7 +1005,7 @@ describe('deliver', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             platformId: 1,
             requestId: 'uuid0',
             timing: {
@@ -1140,7 +1151,7 @@ describe('deliver', () => {
           ],
           request: [
             {
-              ...newBaseRequest(),
+              ...newLogRequestRequest(),
               requestId: 'uuid0',
               timing: {
                 clientLogTimestamp: 12345678,
@@ -1379,7 +1390,7 @@ describe('metrics', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             timing: {
               clientLogTimestamp: 12345678,
@@ -1503,7 +1514,7 @@ describe('metrics', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             paging: {
               size: 1,
@@ -1583,7 +1594,7 @@ describe('metrics', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             sessionId: 'uuid10',
             viewId: 'uuid11',

--- a/src/client.ts
+++ b/src/client.ts
@@ -460,12 +460,7 @@ export class PromotedClientImpl implements PromotedClient {
         const toCompactMetricsInsertion = this.getToCompactMetricsInsertion(deliveryRequest);
         const logRequest = newLogRequest(deliveryRequest);
         if (requestToLog) {
-          const copyRequest = {
-            ...requestToLog,
-          };
-          // Clear the field in case it is set.
-          delete copyRequest['insertion'];
-          logRequest.request = [copyRequest];
+          logRequest.request = [this.createLogRequestRequest(requestToLog)];
           logRequest.insertion = applyPaging(
             deliveryRequest.fullInsertion.map(toCompactMetricsInsertion),
             requestToLog.paging
@@ -481,6 +476,25 @@ export class PromotedClientImpl implements PromotedClient {
       return Promise.resolve(undefined);
     };
   }
+
+  /**
+   * Creates a slimmed-down copy of the request for inclusion in a LogRequest.
+   * @param requestToLog the request to attach to the log request
+   * @returns a copy of the request suitable to be attached to a LogRequest.
+   */
+  createLogRequestRequest = (requestToLog: Request): Request => {
+    const copyRequest = {
+      ...requestToLog,
+    };
+
+    // Clear the field in case it is set.
+    delete copyRequest['insertion'];
+
+    // Clear the userInfo since we already copied it to the LogRequest.
+    delete copyRequest['userInfo'];
+
+    return copyRequest;
+  };
 
   getOnlyLog = (deliveryRequest: DeliveryRequest): boolean => {
     if (deliveryRequest.onlyLog !== undefined) {

--- a/src/types/delivery.d.ts
+++ b/src/types/delivery.d.ts
@@ -12,14 +12,27 @@ export interface Request {
   sessionId?: string;
   useCase?: UseCaseMap[keyof UseCaseMap] | UseCaseString;
   searchQuery?: string;
-  limit?: number;
   insertion?: Array<Insertion>;
   deliveryConfig?: DeliveryConfig;
   properties?: proto_common_common_pb.Properties;
+  paging?: Paging;
+}
+
+export interface Paging {
+  pagingId?: string;
+  size?: number;
+  cursor?: string;
+  offset?: number;
+}
+
+export interface PagingInfo {
+  pagingId?: string;
+  cursor?: string;
 }
 
 export interface Response {
   insertion?: Array<Insertion>;
+  pagingInfo?: PagingInfo;
 }
 
 export interface BlenderRule {


### PR DESCRIPTION
Since userInfo already exists on the LogRequest, including it on child Request objects is redundant. So we will strip them when creating the log request.