### PR TITLE
feat: Don't keep redundant userInfos on children of LogRequest\rTESTING=unit

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -50,6 +50,7 @@ const toInsertionOnlyContentId = (product: Product, extraFields: InsertionFields
   contentId: product.id.toString(),
 });
 
+// Creates a new request.
 const newBaseRequest = (): Partial<Request> => ({
   userInfo: {
     logUserId: 'logUserId1',
@@ -57,6 +58,16 @@ const newBaseRequest = (): Partial<Request> => ({
   useCase: 'FEED',
   // TODO - sessionId: .
   // TODO - viewId: .
+  properties: {
+    struct: {
+      query: 'fakequery',
+    },
+  },
+});
+
+// Creates a  new request passed through the LogRequest, for which the client will strip userInfo.
+const newLogRequestRequest = (): Partial<Request> => ({
+  useCase: 'FEED',
   properties: {
     struct: {
       query: 'fakequery',
@@ -278,7 +289,7 @@ describe('deliver', () => {
           ],
           request: [
             {
-              ...newBaseRequest(),
+              ...newLogRequestRequest(),
               requestId: 'uuid0',
               timing: {
                 clientLogTimestamp: 12345678,
@@ -418,7 +429,7 @@ describe('deliver', () => {
           ],
           request: [
             {
-              ...newBaseRequest(),
+              ...newLogRequestRequest(),
               timing: {
                 clientLogTimestamp: 12345678,
               },
@@ -510,7 +521,7 @@ describe('deliver', () => {
           ],
           request: [
             {
-              ...newBaseRequest(),
+              ...newLogRequestRequest(),
               requestId: 'uuid0',
               timing: {
                 clientLogTimestamp: 12345678,
@@ -595,7 +606,7 @@ describe('deliver', () => {
           ],
           request: [
             {
-              ...newBaseRequest(),
+              ...newLogRequestRequest(),
               requestId: 'uuid0',
               timing: {
                 clientLogTimestamp: 12345678,
@@ -831,7 +842,7 @@ describe('deliver', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             paging: {
               size: 1,
@@ -907,7 +918,7 @@ describe('deliver', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             timing: {
               clientLogTimestamp: 12345678,
@@ -994,7 +1005,7 @@ describe('deliver', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             platformId: 1,
             requestId: 'uuid0',
             timing: {
@@ -1140,7 +1151,7 @@ describe('deliver', () => {
           ],
           request: [
             {
-              ...newBaseRequest(),
+              ...newLogRequestRequest(),
               requestId: 'uuid0',
               timing: {
                 clientLogTimestamp: 12345678,
@@ -1379,7 +1390,7 @@ describe('metrics', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             timing: {
               clientLogTimestamp: 12345678,
@@ -1441,7 +1452,7 @@ describe('metrics', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             paging: {
               size: 1,
@@ -1503,7 +1514,7 @@ describe('metrics', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             paging: {
               size: 1,
@@ -1583,7 +1594,7 @@ describe('metrics', () => {
         ],
         request: [
           {
-            ...newBaseRequest(),
+            ...newLogRequestRequest(),
             requestId: 'uuid0',
             sessionId: 'uuid10',
             viewId: 'uuid11',

--- a/src/client.ts
+++ b/src/client.ts
@@ -460,12 +460,7 @@ export class PromotedClientImpl implements PromotedClient {
         const toCompactMetricsInsertion = this.getToCompactMetricsInsertion(deliveryRequest);
         const logRequest = newLogRequest(deliveryRequest);
         if (requestToLog) {
-          const copyRequest = {
-            ...requestToLog,
-          };
-          // Clear the field in case it is set.
-          delete copyRequest['insertion'];
-          logRequest.request = [copyRequest];
+          logRequest.request = [this.createLogRequestRequest(requestToLog)];
           logRequest.insertion = applyPaging(
             deliveryRequest.fullInsertion.map(toCompactMetricsInsertion),
             requestToLog.paging
@@ -481,6 +476,25 @@ export class PromotedClientImpl implements PromotedClient {
       return Promise.resolve(undefined);
     };
   }
+
+  /**
+   * Creates a slimmed-down copy of the request for inclusion in a LogRequest.
+   * @param requestToLog the request to attach to the log request
+   * @returns a copy of the request suitable to be attached to a LogRequest.
+   */
+  createLogRequestRequest = (requestToLog: Request): Request => {
+    const copyRequest = {
+      ...requestToLog,
+    };
+
+    // Clear the field in case it is set.
+    delete copyRequest['insertion'];
+
+    // Clear the userInfo since we already copied it to the LogRequest.
+    delete copyRequest['userInfo'];
+
+    return copyRequest;
+  };
 
   getOnlyLog = (deliveryRequest: DeliveryRequest): boolean => {
     if (deliveryRequest.onlyLog !== undefined) {


### PR DESCRIPTION
Don't keep redundant userInfos in insertions underneath the LogRequest. Will abandon my other PR for this feature.