### PR TITLE
Split up client.ts and some small cleanups\rTESTING=unit

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,6 @@ import typescript from 'rollup-plugin-typescript2';
 import del from 'rollup-plugin-delete';
 import generatePackageJson from 'rollup-plugin-generate-package-json';
 import pkg from './package.json';
-import { resolve } from 'path';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -1,0 +1,6 @@
+/**
+ * Simple function interface for making API calls.
+ */
+export interface ApiClient<Req, Res> {
+  (request: Req): Promise<Res>;
+}

--- a/src/base-request.ts
+++ b/src/base-request.ts
@@ -1,0 +1,39 @@
+import type { Insertion } from './types/delivery';
+
+export interface InsertionMapFn {
+  (insertion: Insertion): Insertion;
+}
+
+/**
+ * Used to set default values on BaseRequests in the Client's constructor.
+ */
+export interface RequiredBaseRequest {
+  /**
+   * A way to customize when `deliver` should not run an experiment and just log
+   * (CONTROL) vs run through the experiment deliver code path.
+   * Defaults to false.
+   */
+  onlyLog: boolean;
+
+  /** A function to shrink the Insertions on Delivery API. */
+  toCompactDeliveryInsertion: InsertionMapFn;
+  toCompactMetricsInsertion: InsertionMapFn;
+}
+
+/**
+ * Common interface so we can set request values in PromotedClient's constructor.
+ */
+export interface BaseRequest {
+  /**
+   * A way to customize when `deliver` should not run an experiment and just log
+   * (CONTROL) vs run through the experiment deliver code path.
+   * Defaults to false.
+   */
+  onlyLog?: boolean;
+
+  /** Removes unnecessary fields on Insertions for Delivery API. */
+  toCompactDeliveryInsertion?: InsertionMapFn;
+
+  /** Removes unnecessary fields on Insertions for Metrics API. */
+  toCompactMetricsInsertion?: InsertionMapFn;
+}

--- a/src/client-args.ts
+++ b/src/client-args.ts
@@ -1,0 +1,100 @@
+import { ApiClient } from './api-client';
+import { BaseRequest } from './base-request';
+import { ErrorHandler } from './error-handler';
+import { Sampler } from './sampler';
+import type { Request, Response } from './types/delivery';
+import type { CohortMembership, LogRequest, LogResponse } from './types/event';
+
+/**
+ * Arguments for the client so values can be overriden
+ */
+export interface PromotedClientArguments {
+  /**
+   * A way to turn off logging.  Defaults to true.
+   */
+  enabled?: boolean;
+
+  /**
+   * The client used to call Delivery API.  No default so we can reduce network
+   * dependencies on the core library.
+   */
+  deliveryClient: ApiClient<Request, Response>;
+
+  /**
+   * The client used to call Metrics API.  No default so we can reduce network
+   * dependencies on the core library.
+   */
+  metricsClient: ApiClient<LogRequest, LogResponse>;
+
+  /**
+   * Performs extra dev checks.  Safer but slower.  Defaults to true.
+   */
+  performChecks?: boolean;
+
+  /**
+   * Percentage (in the range 0.0-1.0) of logging traffic to forward to
+   * the Delivery API for use as shadow traffic. 0.0 does no forwarding,
+   * and 1.0 forwards every request.
+   */
+  shadowTrafficDeliveryPercent?: number;
+
+  /**
+   * Default values to use on DeliveryRequests.
+   */
+  defaultRequestValues?: BaseRequest;
+
+  /**
+   * Handles errors.
+   * Exposed to give clients flexibility into how errors are handled.
+   * E.g. in dev, throw an error.  In prod, silently log and monitor.
+   *
+   * Example NextJS code:
+   * ```
+   * const throwError =
+   *   process?.env?.NODE_ENV !== 'production' ||
+   *   (typeof location !== "undefined" && location?.hostname === "localhost");
+   * ...
+   * handleError: throwError ? (err) => {
+   *   throw error;
+   * } : (err) => console.error(err);
+   * ```
+   */
+  handleError: ErrorHandler;
+
+  /**
+   * Required as a dependency so clients can load reduce dependency on multiple
+   * uuid libraries.
+   */
+  uuid: () => string;
+
+  /* Defaults to 250ms */
+  deliveryTimeoutMillis?: number;
+
+  /* Defaults to 3000ms */
+  metricsTimeoutMillis?: number;
+
+  /**
+   * Allows for customizing when the treatment gets applied.
+   */
+  shouldApplyTreatment?: (cohortMembership: CohortMembership | undefined) => boolean;
+
+  /**
+   * For testing.  Allows for easy mocking of the clock.
+   */
+  nowMillis?: () => number;
+
+  /**
+   * Exposed for testing, easy mocking of request sampling.
+   */
+  sampler?: Sampler;
+
+  /**
+   * For testing. Used by unit tests to swap out timeout functionality.
+   */
+  deliveryTimeoutWrapper?: <T>(promise: Promise<T>, timeoutMillis: number) => Promise<T>;
+
+  /**
+   * For testing. Used by unit tests to swap out timeout functionality.
+   */
+  metricsTimeoutWrapper?: <T>(promise: Promise<T>, timeoutMillis: number) => Promise<T>;
+}

--- a/src/client-response.ts
+++ b/src/client-response.ts
@@ -1,0 +1,35 @@
+import { Insertion } from './types/delivery';
+import { LogRequest } from './types/event';
+
+/**
+ * A shared response for Metrics or Delivery API.  Makes it easy to swap
+ * out either method.
+ *
+ * Has two main uses:
+ * 1) return a modified list of Insertions.
+ * 2) clients must call the log method after they send their content back
+ * to the client.  They call either `ClientResponse.log` or the `log` helper
+ * method (which hides the Promise).
+ */
+export interface ClientResponse {
+  /**
+   * Sends the log records to Metrics API.
+   * Clients need to call this one of the log methods, preferrably after they
+   * send the response to their UI/apps.
+   */
+  log: () => Promise<void>;
+
+  /**
+   * Creates a LogRequest suitable for calling the metrics client.
+   * Undefined means we do not need any follow up logging
+   */
+  createLogRequest: () => LogRequest | undefined;
+
+  /**
+   * A list of the response Insertions.  This list may be truncated
+   * based on paging parameters, i.e. if Deliver is called with more
+   * items than any optionally provided Paging.size parameter on the
+   * request, at most page size insertions will be forwarded on.
+   */
+  insertion: Insertion[];
+}

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,7 +1,7 @@
 import { copyAndRemoveProperties, log, newPromotedClient, noopFn, NoopPromotedClient, throwOnError } from '.';
-import type { PromotedClientArguments } from '.';
 import type { Insertion, Request } from './types/delivery';
 import { ClientType_PLATFORM_SERVER, TrafficType_PRODUCTION, TrafficType_SHADOW } from './client';
+import { PromotedClientArguments } from './client-args';
 
 const fakeUuidGenerator = () => {
   let i = 0;
@@ -1211,7 +1211,7 @@ describe('deliver', () => {
         deliveryClient,
         metricsClient,
         deliveryTimeoutWrapper: () => Promise.reject(new Error('timeout')),
-        handleError: (error) => {
+        handleError: (error: Error) => {
           // Skip the first error.
           if (numErrors > 0) {
             throw error;
@@ -1305,7 +1305,7 @@ describe('deliver', () => {
         deliveryClient,
         metricsClient,
         metricsTimeoutWrapper: () => Promise.reject(new Error('timeout')),
-        handleError: (error) => {
+        handleError: (error: Error) => {
           // Skip the first error.
           if (numErrors > 0) {
             throw error;

--- a/src/delivery-request.ts
+++ b/src/delivery-request.ts
@@ -35,7 +35,6 @@ export interface DeliveryRequest {
    * overrides do not disable it (`enabled=false` or `onlyLog=true`).
    *
    * If undefined, no experiment is run.  By default, Delivery API is called.
-   * Can be called if `onlyLog` is set to true.
    *
    * If set, this is runs `deliver` as a client-side experiment.  The CONTROL
    * arm does not call Delivery API.  It only logs.  The TREATMENT arm uses

--- a/src/delivery-request.ts
+++ b/src/delivery-request.ts
@@ -1,0 +1,47 @@
+import { InsertionMapFn } from './base-request';
+import { Insertion, Request } from './types/delivery';
+import { CohortMembership } from './types/event';
+
+/**
+ * Represents a single call for retrieving and ranking content.
+ */
+export interface DeliveryRequest {
+  /** Removes unnecessary fields on Insertions for Delivery API. */
+  toCompactDeliveryInsertion?: InsertionMapFn;
+
+  /** Removes unnecessary fields on Insertions for Metrics API. */
+  toCompactMetricsInsertion?: InsertionMapFn;
+
+  /**
+   * The Request for content.
+   */
+  request: Request;
+
+  /**
+   * Insertions with all metadata.  The `toCompact` functions are used to
+   * transform the fullInsertion to Insertions on each of the requests.
+   */
+  fullInsertion: Insertion[];
+
+  /**
+   * A way to customize when `deliver` should not run an experiment and just log
+   * (CONTROL) vs run through the experiment deliver code path.
+   * Defaults to false.
+   */
+  onlyLog?: boolean;
+
+  /**
+   * Used to run a client-side experiment.  Activation happens if other
+   * overrides do not disable it (`enabled=false` or `onlyLog=true`).
+   *
+   * If undefined, no experiment is run.  By default, Delivery API is called.
+   * Can be called if `onlyLog` is set to true.
+   *
+   * If set, this is runs `deliver` as a client-side experiment.  The CONTROL
+   * arm does not call Delivery API.  It only logs.  The TREATMENT arm uses
+   * Delivery API to change Insertions.
+   *
+   * This CohortMembership is also logged to Metrics.
+   */
+  experiment?: CohortMembership;
+}

--- a/src/error-handler.test.ts
+++ b/src/error-handler.test.ts
@@ -1,0 +1,10 @@
+import { logOnError } from './error-handler';
+
+describe('log error handler', () => {
+  it('console.error simple text"', () => {
+    console.error = jest.fn();
+    const err = new Error('hello');
+    logOnError(err);
+    expect(console.error).toHaveBeenCalledWith(err);
+  });
+});

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -1,0 +1,15 @@
+export interface ErrorHandler {
+  (err: Error): void;
+}
+
+/**
+ * Simple ErrorHandler that throws the error.
+ */
+export const throwOnError: ErrorHandler = (err) => {
+  throw err;
+};
+
+/**
+ * Simple ErrorHandler that logs to console.err.
+ */
+export const logOnError: ErrorHandler = (err) => console.error(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
+export * from './api-client';
+export * from './base-request';
+export * from './client-args';
+export * from './client-response';
+export * from './delivery-request';
+export * from './error-handler';
+export * from './metrics-request';
 export * from './client';
 export * from './experiment';
 

--- a/src/metrics-request.ts
+++ b/src/metrics-request.ts
@@ -1,0 +1,21 @@
+import { InsertionMapFn } from './base-request';
+import { Insertion, Request } from './types/delivery';
+
+/**
+ * Represents a single call for logging content.
+ */
+export interface MetricsRequest {
+  /** A function to shrink the Insertions on Metrics API. */
+  toCompactMetricsInsertion?: InsertionMapFn;
+
+  /**
+   * The Request for content.
+   */
+  request: Request;
+
+  /**
+   * Insertions with all metadata.  The `toCompact` functions are used to
+   * transform the fullInsertion to Insertions on each of the requests.
+   */
+  fullInsertion: Insertion[];
+}


### PR DESCRIPTION
Mostly breaking out exported interfaces into their own files, which should make the client code easier to read and port. Also marked some things private and simplified some code with ??.