### PR TITLE
fix: how shadow traffic impacts with compact insertions fn

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -41,7 +41,7 @@ const newProduct = (id: string): Product => ({
 // Response insertions should always have position assigned.
 const toResponseInsertions = (products: Product[]): Insertion[] =>
   products.map((product, idx) => {
-    // TODO - we'll change these to just have contentId soon.
+    // TODO - we'll change these to have contentId and position.
     return toFullInsertion(product, { position: idx });
   });
 

--- a/src/metrics-request.ts
+++ b/src/metrics-request.ts
@@ -6,7 +6,10 @@ import { Insertion, Request } from './types/delivery';
  * Represents a single call for logging content.
  */
 export interface MetricsRequest {
-  /** A function to shrink the Properties on Metrics API. */
+  /** Removes unnecessary fields on Insertions for Delivery API shadow traffic calls. */
+  toCompactDeliveryProperties?: PropertiesMapFn;
+
+  /** Removes unnecessary fields on Insertions for Metrics API. */
   toCompactMetricsProperties?: PropertiesMapFn;
 
   /**


### PR DESCRIPTION
Previously, it was ignored.  This PR applies compaction functions to shadow traffic Request Insertions.

This also contains a small set of function renames to make the insertion details more obvious.

TESTING=unit tests