### PR TITLE
feat: Fill in DeliveryExecution.serverVersion\rTESTING=unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,5 @@ typings/
 .idea
 dist/
 .vscode/
+.history/
 promoted-ts-client.code-workspace

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ When you want to undo, run `npm run unlink` in this directory and `npm unlink pr
 
 ## Deploy
 
+Based on the anticipated semantic-version, update the `SERVER_VERSION` constant in `client.ts`.
+
 We use a GitHub action that runs semantic-release to determine how to update versions. Just do a normal code review and this should work. Depending on the message prefixes (e.g. `feat: `, `fix: `, `clean: `, `docs: `), it'll update the version appropriately.
 
 # Resources

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,6 +1,6 @@
 import { log, newPromotedClient, noopFn, NoopPromotedClient, throwOnError } from '.';
 import type { Insertion, Request } from './types/delivery';
-import { ClientType_PLATFORM_SERVER, TrafficType_PRODUCTION, TrafficType_SHADOW } from './client';
+import { ClientType_PLATFORM_SERVER, TrafficType_PRODUCTION, TrafficType_SHADOW, SERVER_VERSION } from './client';
 import { PromotedClientArguments } from './client-args';
 import { InsertionPageType } from './insertion-page-type';
 import { DeliveryRequest } from './delivery-request';
@@ -528,6 +528,7 @@ describe('deliver', () => {
             },
             execution: {
               executionServer: 2,
+              serverVersion: SERVER_VERSION,
             },
           },
         ],
@@ -660,6 +661,7 @@ describe('deliver', () => {
             },
             execution: {
               executionServer: 2,
+              serverVersion: SERVER_VERSION,
             },
           },
         ],
@@ -851,6 +853,7 @@ describe('deliver', () => {
             },
             execution: {
               executionServer: 2,
+              serverVersion: SERVER_VERSION,
             },
           },
         ],
@@ -970,6 +973,7 @@ describe('deliver', () => {
             },
             execution: {
               executionServer: 2,
+              serverVersion: SERVER_VERSION,
             },
           },
         ],
@@ -1084,6 +1088,7 @@ describe('deliver', () => {
             },
             execution: {
               executionServer: 2,
+              serverVersion: SERVER_VERSION,
             },
           },
         ],
@@ -1359,6 +1364,7 @@ describe('deliver', () => {
           },
           execution: {
             executionServer: 2,
+            serverVersion: SERVER_VERSION,
           },
         },
       ],
@@ -1451,6 +1457,7 @@ describe('deliver', () => {
           },
           execution: {
             executionServer: 2,
+            serverVersion: SERVER_VERSION,
           },
         },
       ],
@@ -1560,6 +1567,7 @@ describe('deliver', () => {
           },
           execution: {
             executionServer: 2,
+            serverVersion: SERVER_VERSION,
           },
         },
       ],
@@ -1733,6 +1741,7 @@ describe('deliver', () => {
             },
             execution: {
               executionServer: 2,
+              serverVersion: SERVER_VERSION,
             },
           },
         ],
@@ -2029,6 +2038,7 @@ describe('metrics', () => {
           },
           execution: {
             executionServer: 2,
+            serverVersion: SERVER_VERSION,
           },
         },
       ],
@@ -2106,6 +2116,7 @@ describe('metrics', () => {
           },
           execution: {
             executionServer: 2,
+            serverVersion: SERVER_VERSION,
           },
         },
       ],
@@ -2173,6 +2184,7 @@ describe('metrics', () => {
           },
           execution: {
             executionServer: 2,
+            serverVersion: SERVER_VERSION,
           },
         },
       ],
@@ -2255,6 +2267,7 @@ describe('metrics', () => {
           },
           execution: {
             executionServer: 2,
+            serverVersion: SERVER_VERSION,
           },
         },
       ],
@@ -2332,6 +2345,7 @@ describe('metrics', () => {
           },
           execution: {
             executionServer: 2,
+            serverVersion: SERVER_VERSION,
           },
         },
       ],
@@ -2428,6 +2442,7 @@ describe('metrics', () => {
           },
           execution: {
             executionServer: 2,
+            serverVersion: SERVER_VERSION,
           },
         },
       ],
@@ -2567,6 +2582,7 @@ describe('shadow requests in prepareForLogging', () => {
           },
           execution: {
             executionServer: 2,
+            serverVersion: SERVER_VERSION,
           },
         },
       ],

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,6 +13,10 @@ import type { CohortMembership, LogRequest, LogResponse } from './types/event';
 import { Pager } from './pager';
 import { ExecutionServer } from './execution-server';
 
+// Version number that semver will generate for the package.
+// Must be manually maintained.
+export const SERVER_VERSION = 'ts.7.2.2';
+
 /**
  * Design-wise
  *
@@ -399,6 +403,7 @@ export class PromotedClientImpl implements PromotedClient {
           },
           execution: {
             executionServer: ExecutionServer.SDK,
+            serverVersion: SERVER_VERSION,
           },
         },
       ];

--- a/src/types/delivery.d.ts
+++ b/src/types/delivery.d.ts
@@ -46,6 +46,7 @@ export interface Response {
 
 export interface DeliveryExecution {
   executionServer?: ExecutionServerMap[keyof ExecutionServerMap] | ExecutionServerString;
+  serverVersion?: string;
 }
 
 export interface ExecutionServerMap {


### PR DESCRIPTION
I was not able to learn of a safe way to fill in server version based on the generated semver, so I suggest we try to keep this field updated in code manually, best-effort.