### PR TITLE
feat: hasinsertionid requires insertionid field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promoted-ts-client",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "A Typescript Client to contact Promoted APIs.",
   "scripts": {
     "prettier": "prettier '**/*.{js,ts}' --ignore-path ./.prettierignore",

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,7 +14,7 @@ import { ExecutionServer } from './execution-server';
 
 // Version number that semver will generate for the package.
 // Must be manually maintained.
-export const SERVER_VERSION = 'ts.8.0.0';
+export const SERVER_VERSION = 'ts.8.1.0';
 
 /**
  * Design-wise

--- a/src/map-response.test.ts
+++ b/src/map-response.test.ts
@@ -8,7 +8,7 @@ const insertion = (contentId: string, insertionId: string): Insertion => ({
 
 type Content = {
   name: string;
-  insertionId?: string;
+  insertionId: string | undefined | null;
 };
 
 describe('toContents', () => {
@@ -17,7 +17,7 @@ describe('toContents', () => {
   });
 
   it('empty array', () => {
-    const contentLookup: Record<string, Content> = { a: { name: 'a' } };
+    const contentLookup: Record<string, Content> = { a: { name: 'a', insertionId: undefined } };
     expect(toContents<Content>([], contentLookup)).toEqual([]);
   });
 
@@ -27,9 +27,9 @@ describe('toContents', () => {
 
   it('empty array', () => {
     const contentLookup: Record<string, Content> = {
-      '1': { name: 'a' },
-      '2': { name: 'b' },
-      '3': { name: 'c' },
+      '1': { name: 'a', insertionId: undefined },
+      '2': { name: 'b', insertionId: undefined },
+      '3': { name: 'c', insertionId: undefined },
     };
     const insertions: Insertion[] = [
       insertion('2', 'uuid1'),
@@ -50,22 +50,26 @@ describe('toContents', () => {
   });
 });
 
+type ContentWithoutInsertion = {
+  name: string;
+};
+
 describe('toContentsWithoutInsertionId', () => {
   it('empty', () => {
     expect(toContentsWithoutInsertionId([], {})).toEqual([]);
   });
 
   it('empty array', () => {
-    const contentLookup: Record<string, Content> = { a: { name: 'a' } };
-    expect(toContentsWithoutInsertionId<Content>([], contentLookup)).toEqual([]);
+    const contentLookup: Record<string, ContentWithoutInsertion> = { a: { name: 'a' } };
+    expect(toContentsWithoutInsertionId<ContentWithoutInsertion>([], contentLookup)).toEqual([]);
   });
 
   it('empty contentLookup', () => {
-    expect(toContentsWithoutInsertionId<Content>([insertion('content1', 'uuid1')], {})).toEqual([]);
+    expect(toContentsWithoutInsertionId<ContentWithoutInsertion>([insertion('content1', 'uuid1')], {})).toEqual([]);
   });
 
   it('empty array', () => {
-    const contentLookup: Record<string, Content> = {
+    const contentLookup: Record<string, ContentWithoutInsertion> = {
       '1': { name: 'a' },
       '2': { name: 'b' },
       '3': { name: 'c' },
@@ -76,7 +80,7 @@ describe('toContentsWithoutInsertionId', () => {
       insertion('3', 'uuid3'),
       insertion('', 'uuid4'),
     ];
-    expect(toContentsWithoutInsertionId<Content>(insertions, contentLookup)).toEqual([
+    expect(toContentsWithoutInsertionId<ContentWithoutInsertion>(insertions, contentLookup)).toEqual([
       {
         name: 'b',
       },

--- a/src/map-response.ts
+++ b/src/map-response.ts
@@ -1,7 +1,7 @@
 import { Insertion } from './types/delivery';
 
 interface HasInsertionId {
-  insertionId?: string;
+  insertionId: string | undefined | null;
 }
 
 /**


### PR DESCRIPTION
Switches from operational property to requiring a property but allowing undefined and null values.  This is a little safer if someone is coding against us.

This is technically a breaking change but I don't want to do another major version bump for this.

TESTING=unit tests