### PR TITLE
refactor: add "method" to the error wrapper

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -995,7 +995,9 @@ describe('deliver', () => {
       expect(deliveryClient.mock.calls.length).toBe(1);
       expect(metricsClient.mock.calls.length).toBe(1);
       expect(errors.length).toBe(numExpectedErrors);
-      expect(errors[0].toString()).toEqual('Error: Delivery should not be called in timeout; clientRequestId=uuid0');
+      expect(errors[0].toString()).toEqual(
+        'Error: Delivery should not be called in timeout; delivery, clientRequestId=uuid0'
+      );
     });
 
     // This test does not fully test timeouts.
@@ -1074,7 +1076,7 @@ describe('deliver', () => {
       expect(deliveryClient.mock.calls.length).toBe(1);
       expect(metricsClient.mock.calls.length).toBe(1);
       expect(errors.length).toBe(numExpectedErrors);
-      expect(errors[0].toString()).toEqual('Error: timeout; clientRequestId=uuid0');
+      expect(errors[0].toString()).toEqual('Error: timeout; metrics, clientRequestId=uuid0');
     });
 
     it('shadow traffic timeout', async () => {
@@ -1140,7 +1142,7 @@ describe('deliver', () => {
       expect(deliveryClient.mock.calls.length).toBe(1);
       expect(metricsClient.mock.calls.length).toBe(1);
       expect(errors.length).toBe(numExpectedErrors);
-      expect(errors[0].toString()).toEqual('Error: timeout; clientRequestId=uuid0');
+      expect(errors[0].toString()).toEqual('Error: timeout; shadow delivery, clientRequestId=uuid0');
     });
   });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -242,7 +242,7 @@ export class PromotedClientImpl implements PromotedClient {
           responseInsertions = response.insertion ?? [];
         }
       } catch (error) {
-        this.handleRequestError(error, request.clientRequestId);
+        this.handleRequestError(error, 'delivery', request.clientRequestId);
       }
     }
     if (!attemptedDeliveryApi && this.shouldSendAsShadowTraffic()) {
@@ -303,7 +303,7 @@ export class PromotedClientImpl implements PromotedClient {
       .then(() => {
         /* do nothing */
       })
-      .catch((error) => this.handleRequestError(error, request.clientRequestId));
+      .catch((error) => this.handleRequestError(error, 'shadow delivery', request.clientRequestId));
   }
 
   /**
@@ -366,7 +366,7 @@ export class PromotedClientImpl implements PromotedClient {
       try {
         await this.metricsTimeoutWrapper(this.metricsClient(logRequest), this.metricsTimeoutMillis);
       } catch (error) {
-        this.handleRequestError(error, clientRequestId);
+        this.handleRequestError(error, 'metrics', clientRequestId);
       }
       return Promise.resolve(undefined);
     };
@@ -389,9 +389,9 @@ export class PromotedClientImpl implements PromotedClient {
   };
 
   // The wrapped Error loses the original stack trace.
-  private handleRequestError = (error: Error, clientRequestId: string | undefined) => {
+  private handleRequestError = (error: Error, method: string, clientRequestId: string | undefined) => {
     const message = error.message ?? error.toString();
-    this.handleError(new Error(`${message}; clientRequestId=${clientRequestId}`));
+    this.handleError(new Error(`${message}; ${method}, clientRequestId=${clientRequestId}`));
   };
 }
 


### PR DESCRIPTION
This helps clients separate if metrics or shadowtraffic has errors.

TESTING=unit tests