### PR TITLE
docs: got and node-fetch http clients

### DIFF
--- a/axios.md
+++ b/axios.md
@@ -1,0 +1,32 @@
+# Using `axios`
+
+`axios` provides an easier setup but other company benchmarks regularly show `node-fetch` provides lower latencies.
+
+```typescript
+import axios from 'axios';
+import https from "https";
+
+// promoted-ts-client does not currently support warming up the connection.
+const httpsAgent = new https.Agent({
+  keepAlive: true,
+  // You need to optimize this.
+  maxSockets: 50,
+});
+
+const apiClient = <Req, Res>(
+  url: string,
+  apiKey: string,
+  timeout: number
+) => async (request: Req): Promise<Res> => {
+  const response = await axios.post(url, request, {
+    headers: {
+      "Content-Type": "application/json",
+      "Accept-Encoding": "gzip",
+      "x-api-key": apiKey
+    },
+    httpsAgent,
+    timeout
+  });
+  return response.data;
+};
+```

--- a/got.md
+++ b/got.md
@@ -1,0 +1,33 @@
+# Using `got`
+
+[got](https://github.com/sindresorhus/got#comparison) has some great benefits (HTTP/2) over other HTTP clients if your server can support it:
+- Supports HTTP/2.  Requires NodeJS `>=15.10.0`.
+- Only supports ESM (not CJS).  There is a `got-cjs`.  Promoted has not performed security checks on that package.
+- Other libraries with http clients and global http settings can break `got`.
+
+```typescript
+import got from "got";
+
+const apiClient = <Req, Res>(
+  urlString: string,
+  apiKey: string,
+  timeout: number
+) => async (requestBody: Req): Promise<Res> => {
+  return got.post(
+    urlString,
+    {
+      json: requestBody,
+      headers: {
+        "Content-Type": "application/json",
+        "Accept-Encoding": "gzip",
+        "x-api-key": apiKey
+      },
+      // http2 needs Nodejs 15.10.0 and above.
+      http2: true,
+      timeout: {
+        request: timeout
+      }
+    }
+  ).json();
+};
+```


### PR DESCRIPTION
Might make sense to move the optional clients to a different markdown file.

TESTING=none