### PR TITLE
feat: support client-specified clientinfo

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -15,7 +15,7 @@ import { Validator } from './validator';
 
 // Version number that semver will generate for the package.
 // Must be manually maintained.
-export const SERVER_VERSION = 'ts.8.3.2';
+export const SERVER_VERSION = 'ts.8.4.0';
 
 /**
  * Design-wise

--- a/src/client.ts
+++ b/src/client.ts
@@ -227,9 +227,10 @@ export class PromotedClientImpl implements PromotedClient {
           const singleRequest: Request = {
             ...request,
             clientInfo: {
-              ...request.clientInfo,
               trafficType: TrafficType_PRODUCTION,
               clientType: ClientType_PLATFORM_SERVER,
+              // Expand `request.clientInfo` after so we can use client-specified trafficType or clientType.
+              ...request.clientInfo,
             },
           };
 
@@ -293,9 +294,10 @@ export class PromotedClientImpl implements PromotedClient {
     const singleRequest: Request = {
       ...request,
       clientInfo: {
-        ...request.clientInfo,
         trafficType: TrafficType_SHADOW,
         clientType: ClientType_PLATFORM_SERVER,
+        // Expand `request.clientInfo` after so we can use client-specified trafficType or clientType.
+        ...request.clientInfo,
       },
     };
     // Swallow errors.
@@ -333,9 +335,12 @@ export class PromotedClientImpl implements PromotedClient {
       // Ignore any common fields set on CohortMembership.
     }
 
-    logRequest.clientInfo = { ...logRequest.clientInfo };
-    logRequest.clientInfo.clientType = ClientType_PLATFORM_SERVER;
-    logRequest.clientInfo.trafficType = TrafficType_PRODUCTION;
+    logRequest.clientInfo = {
+      clientType: ClientType_PLATFORM_SERVER,
+      trafficType: TrafficType_PRODUCTION,
+      // Expand `request.clientInfo` after so we can use client-specified trafficType or clientType.
+      ...logRequest.clientInfo,
+    };
 
     // TODO - strip redundant fields off of child records.
 

--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -18,8 +18,8 @@ export interface Properties {
   struct?: any;
 }
 
-export type TrafficType = 0 | 1 | 2 | 4;
-export type ClientType = 0 | 1 | 2;
+export type TrafficType = 0 | 1 | 2 | 4 | 5 | 'UNKNOWN_TRAFFIC_TYPE' | 'PRODUCTION' | 'REPLAY' | 'SHADOW' | 'LOAD_TEST';
+export type ClientType = 0 | 1 | 2 | 'UNKNOWN_REQUEST_CLIENT' | 'PLATFORM_SERVER' | 'PLATFORM_CLIENT';
 
 export interface ClientInfo {
   trafficType?: TrafficType;


### PR DESCRIPTION
This allows clients to override the defaults.  E.g. set `trafficType='LOAD_TEST'`.

TESTING=unit tests