### PR TITLE
fix: experiment modulo; default buckets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promoted-ts-client",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "A Typescript Client to contact Promoted APIs.",
   "scripts": {
     "prettier": "prettier '**/*.{js,ts}' --ignore-path ./.prettierignore",

--- a/src/experiment.test.ts
+++ b/src/experiment.test.ts
@@ -104,7 +104,6 @@ describe('twoArmExperimentConfig', () => {
   });
 
   it('partial bucket', () => {
-    // This is kinda buggy.
     expect(twoArmExperimentConfig5050('v1', 2.5, 2.5)).toEqual({
       cohortId: 'v1',
       cohortIdHash: 3707,

--- a/src/hash.test.ts
+++ b/src/hash.test.ts
@@ -1,4 +1,4 @@
-import { combineHash, hashCode } from './hash';
+import { combineHash, hashCode, mod } from './hash';
 
 it('empty', () => {
   expect(hashCode('')).toEqual(0);
@@ -14,4 +14,16 @@ it('simple', () => {
 it('combineHash', () => {
   expect(combineHash(268162990, -276881852)).toEqual(8036187175);
   expect(combineHash(268162990, 2142660)).toEqual(8315211687);
+});
+
+it('mod', () => {
+  expect(mod(0, 10)).toEqual(0);
+  expect(mod(5, 10)).toEqual(5);
+  expect(mod(10, 10)).toEqual(0);
+  expect(mod(15, 10)).toEqual(5);
+  expect(mod(13123011, 10)).toEqual(1);
+  expect(mod(-1, 10)).toEqual(9);
+  expect(mod(-5, 10)).toEqual(5);
+  expect(mod(-10, 10)).toEqual(0);
+  expect(mod(-234123, 10)).toEqual(7);
 });

--- a/src/hash.ts
+++ b/src/hash.ts
@@ -24,3 +24,8 @@ export const combineHash = (hash1: number, hash2: number): number => {
   hash = hash * 31 + hash2;
   return hash;
 };
+
+// Supports negative numbers.  '%' is remainder in Typescript.
+export const mod = (value: number, modulo: number): number => {
+  return ((value % modulo) + modulo) % modulo;
+};


### PR DESCRIPTION
BREAKING CHANGE: This changes the experiment arms that users will be in.

This fixes two issues:
1. The modulo logic is wrong for negative numbers.  Typescript '%' is a remainder function.
2. Change the default user buckets to 1k so experiment arm percents work down to 0.1%.

TESTING=unit tests