### PR TITLE
fix: the promoted-ts-client version string

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -14,7 +14,7 @@ import { Validator } from './validator';
 
 // Version number that semver will generate for the package.
 // Must be manually maintained.
-export const SERVER_VERSION = 'ts.8.4.0';
+export const SERVER_VERSION = 'ts.10.1.1';
 
 /**
  * Design-wise


### PR DESCRIPTION
The real reason for this PR is to force an actual NPM deployment to test out a recent change.