### PR TITLE
feat: validate Delivery response

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const apiClient = <Req, Res>(
   url: string,
   apiKey: string,
   timeoutMs: number
-) => async (request: Req): Promise<Res> => {
+) => async (request: Req): Promise<any> => {
   // AbortController was added in node v14.17.0 globally.
   // This can brought in as a normal import too.
   const AbortController = globalThis.AbortController || await import('abort-controller')
@@ -97,7 +97,11 @@ const apiClient = <Req, Res>(
       agent,
       signal: controller.signal,
     });
-    return response.json();
+    const responseText = await response.text();
+    if (!response.ok) {
+      throw new Error(`Promoted ${name} API call failed; response=${responseText}`);
+    }
+    return responseText;
   } finally {
     clearTimeout(timeout);
   }
@@ -148,11 +152,11 @@ cacheable.install(httpsAgent);
 
 ### ApiClient
 
-Wrapper for API clients used to make Delivery and Metrics API calls to Promoted.
+Wrapper for API clients used to make Delivery and Metrics API calls to Promoted.  Return either the response as a JSON string or parsed object.
 
 ```typescript
-export interface ApiClient<Req, Res> {
-  (request: Req): Promise<Res>;
+export interface ApiClient<Req> {
+  (request: Req): Promise<any>;
 }
 ```
 

--- a/got.md
+++ b/got.md
@@ -13,7 +13,7 @@ const apiClient = <Req, Res>(
   apiKey: string,
   timeout: number
 ) => async (requestBody: Req): Promise<Res> => {
-  return got.post(
+  const response = got.post(
     urlString,
     {
       json: requestBody,

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -252,7 +252,9 @@ describe('deliver', () => {
     const deliveryClient = jest.fn((request) => {
       expect(request).toEqual(expectedRequest());
       return Promise.resolve({
+        requestId: 'uuid1',
         insertion: expectedResponseInsertionsForDelivery(),
+        pagingInfo: {},
       });
     });
     const metricsClient = jest.fn(failFunction('All data should be logged in Delivery API'));
@@ -290,7 +292,9 @@ describe('deliver', () => {
         insertion: toRequestInsertions([newProduct('3'), newProduct('2')]),
       });
       return Promise.resolve({
+        requestId: 'uuid1',
         insertion: responseInsertions,
+        pagingInfo: {},
       });
     });
     const metricsClient = jest.fn(failFunction('All data should be logged in Delivery API'));
@@ -325,7 +329,9 @@ describe('deliver', () => {
         insertion: [],
       });
       return Promise.resolve({
+        requestId: 'uuid1',
         insertion: [],
+        pagingInfo: {},
       });
     });
     const metricsClient = jest.fn(failFunction('All data should be logged in Delivery API'));
@@ -367,7 +373,9 @@ describe('deliver', () => {
         insertion: [],
       });
       return Promise.resolve({
+        requestId: 'uuid1',
         insertion: [],
+        pagingInfo: {},
       });
     });
     const metricsClient = jest.fn(failFunction('All data should be logged in Delivery API'));
@@ -409,7 +417,9 @@ describe('deliver', () => {
       expectedReq.paging = { offset: 520, size: 10 };
       expect(request).toEqual(expectedReq);
       return Promise.resolve({
+        requestId: 'uuid1',
         insertion: expectedResponseInsertionsForDelivery(),
+        pagingInfo: {},
       });
     });
     const metricsClient = jest.fn(failFunction('All data should be logged in Delivery API'));
@@ -460,6 +470,8 @@ describe('deliver', () => {
             },
             response: {
               insertion: expectedResponseInsertionsForMetrics(),
+              pagingInfo: {},
+              requestId: 'uuid1',
             },
             execution: {
               executionServer: 2,
@@ -517,11 +529,13 @@ describe('deliver', () => {
         });
         return Promise.resolve({
           // This is ignored since it's shadow traffic.
+          requestId: request.requestId,
           insertion: [
             toResponseInsertion('product1', 'uuid4', 0),
             toResponseInsertion('product2', 'uuid5', 1),
             toResponseInsertion('product3', 'uuid6', 2),
           ],
+          pagingInfo: {},
         });
       });
       const expectedLogReq: LogRequest = {
@@ -542,7 +556,9 @@ describe('deliver', () => {
               device: TEST_DEVICE,
             },
             response: {
+              requestId: 'uuid1',
               insertion: expectedResponseInsertionsForMetrics(),
+              pagingInfo: {},
             },
             execution: {
               executionServer: 2,
@@ -596,6 +612,7 @@ describe('deliver', () => {
           insertion: toRequestInsertions([newProduct('3'), newProduct('2'), newProduct('1')]),
         });
         return Promise.resolve({
+          requestId: 'uuid1',
           insertion: expectedResponseInsertionsForDelivery(),
         });
       });
@@ -662,7 +679,9 @@ describe('deliver', () => {
               device: TEST_DEVICE,
             },
             response: {
+              requestId: 'uuid1',
               insertion: expectedResponseInsertionsForMetrics(),
+              pagingInfo: {},
             },
             execution: {
               executionServer: 2,
@@ -732,7 +751,9 @@ describe('deliver', () => {
             device: TEST_DEVICE,
           },
           response: {
+            requestId: 'uuid1',
             insertion: [toResponseInsertion('product3', 'uuid2', 0)],
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,
@@ -794,7 +815,9 @@ describe('deliver', () => {
             device: TEST_DEVICE,
           },
           response: {
+            requestId: 'uuid1',
             insertion: expectedResponseInsertionsForMetrics(),
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,
@@ -858,7 +881,9 @@ describe('deliver', () => {
             device: TEST_DEVICE,
           },
           response: {
+            requestId: 'uuid1',
             insertion: expectedResponseInsertionsForMetrics(),
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,
@@ -909,6 +934,7 @@ describe('deliver', () => {
     const deliveryClient = jest.fn((request) => {
       expect(request).toEqual(expectedRequest());
       return Promise.resolve({
+        requestId: 'uuid1',
         insertion: [
           {
             insertionId: 'uuid1',
@@ -917,6 +943,7 @@ describe('deliver', () => {
           toResponseInsertion('product2', 'uuid2', 1),
           toResponseInsertion('product3', 'uuid3', 2),
         ],
+        pagingInfo: {},
       });
     });
     const metricsClient = jest.fn(failFunction('All data should be logged in Delivery API'));
@@ -972,7 +999,9 @@ describe('deliver', () => {
               requestId: 'uuid1',
             },
             response: {
+              requestId: 'uuid1',
               insertion: expectedResponseInsertionsForMetrics(),
+              pagingInfo: {},
             },
             execution: {
               executionServer: 2,
@@ -1042,6 +1071,7 @@ describe('deliver', () => {
           clientRequestId: 'uuid0',
         });
         return Promise.resolve({
+          requestId: 'uuid1',
           insertion: expectedResponseInsertionsForMetrics(),
         });
       });
@@ -1118,7 +1148,9 @@ describe('deliver', () => {
               requestId: 'uuid1',
             },
             response: {
+              requestId: 'uuid1',
               insertion: expectedResponseInsertionsForMetrics(),
+              pagingInfo: {},
             },
             execution: {
               executionServer: 2,
@@ -1312,11 +1344,13 @@ describe('deliver with onlyLog=true', () => {
             requestId: 'uuid1',
           },
           response: {
+            requestId: 'uuid1',
             insertion: [
               toResponseInsertion('product3', 'uuid2', 0),
               toResponseInsertion('product2', 'uuid3', 1),
               toResponseInsertion('product1', 'uuid4', 2),
             ],
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,
@@ -1366,7 +1400,9 @@ describe('deliver with onlyLog=true', () => {
             insertion: [],
           },
           response: {
+            requestId: 'uuid1',
             insertion: [],
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,
@@ -1423,7 +1459,9 @@ describe('deliver with onlyLog=true', () => {
             insertion: [],
           },
           response: {
+            requestId: 'uuid1',
             insertion: [],
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,
@@ -1481,7 +1519,9 @@ describe('deliver with onlyLog=true', () => {
             },
           },
           response: {
+            requestId: 'uuid1',
             insertion: [toResponseInsertion('product3', 'uuid2', 0)],
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,
@@ -1539,7 +1579,9 @@ describe('deliver with onlyLog=true', () => {
             },
           },
           response: {
+            requestId: 'uuid1',
             insertion: [toResponseInsertion('product3', 'uuid2', 100)],
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,
@@ -1591,7 +1633,9 @@ describe('deliver with onlyLog=true', () => {
             },
           },
           response: {
+            requestId: 'uuid1',
             insertion: [toResponseInsertion('product2', 'uuid2', 1)],
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,
@@ -1648,7 +1692,9 @@ describe('deliver with onlyLog=true', () => {
             viewId: 'uuid11',
           },
           response: {
+            requestId: 'uuid1',
             insertion: expectedResponseInsertionsForMetrics(),
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,
@@ -1731,7 +1777,9 @@ describe('shadow requests', () => {
             device: TEST_DEVICE,
           },
           response: {
+            requestId: 'uuid1',
             insertion: [toResponseInsertion('product3', 'uuid2', 0)],
+            pagingInfo: {},
           },
           execution: {
             executionServer: 2,

--- a/src/types/delivery.d.ts
+++ b/src/types/delivery.d.ts
@@ -40,8 +40,9 @@ export interface PagingInfo {
 }
 
 export interface Response {
-  insertion?: Array<Insertion>;
-  pagingInfo?: PagingInfo;
+  requestId: string;
+  insertion: Array<Insertion>;
+  pagingInfo: PagingInfo;
 }
 
 export interface DeliveryExecution {

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -1,4 +1,4 @@
-import { Validator } from './validator';
+import { Validator, validateResponse } from './validator';
 import { DeliveryRequest } from './delivery-request';
 
 describe('validator', () => {
@@ -198,5 +198,70 @@ describe('validator', () => {
         'offset(0) should be >= insertionStart(10).  offset should be the global position.'
       );
     });
+  });
+});
+
+describe('validateResponse', () => {
+  it('valid w/o insertion', () => {
+    const response = validateResponse({
+      requestId: 'uuid1',
+    });
+    expect(response).toEqual({
+      requestId: 'uuid1',
+      insertion: [],
+      pagingInfo: {},
+    });
+  });
+
+  it('valid w/ optional fields set', () => {
+    const response = validateResponse({
+      requestId: 'uuid1',
+      insertion: [{ contentId: '1' }],
+      pagingInfo: { cursor: 'cursor1' },
+    });
+    expect(response).toEqual({
+      requestId: 'uuid1',
+      insertion: [{ contentId: '1' }],
+      pagingInfo: { cursor: 'cursor1' },
+    });
+  });
+
+  it('valid as json', () => {
+    const responseInput = {
+      requestId: 'uuid1',
+      insertion: [{ contentId: '1' }],
+      pagingInfo: { cursor: 'cursor1' },
+    };
+    const response = validateResponse(JSON.stringify(responseInput));
+    expect(response).toEqual({
+      requestId: 'uuid1',
+      insertion: [{ contentId: '1' }],
+      pagingInfo: { cursor: 'cursor1' },
+    });
+  });
+
+  it('empty', () => {
+    expect(() => validateResponse({})).toThrow('Invalid Delivery Response.  Expected requestId.');
+  });
+
+  it('error json parsing', () => {
+    expect(() => validateResponse('not json')).toThrow(`Invalid Delivery Response.  Not valid JSON.`);
+  });
+
+  it('error', () => {
+    expect(() =>
+      validateResponse({
+        error: 'some error',
+      })
+    ).toThrow(`Invalid Delivery Response.  'error' was encountered.`);
+  });
+
+  it('error insertion not an array', () => {
+    expect(() =>
+      validateResponse({
+        requestId: 'uuid1',
+        insertion: 'somestring',
+      })
+    ).toThrow('Invalid Delivery Response.  Expected insertions as Array.');
   });
 });


### PR DESCRIPTION
fixes PRO-4312

BREAKING CHANGE: This changes the interface to ApiClient.

This PR supports:
- Validating the Delivery Response.  It checks for `requestId` which will catch most integration errors.
- Simplify the ApiClient code by accepting `any` and handling the validation internally.

TODO - I need to update the axios and got examples.

TESTING=Unit tests.  I'll try this in a code base after merging the PR.