### PR TITLE
fix: validate the response to shadow traffic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promoted-ts-client",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "A Typescript Client to contact Promoted APIs.",
   "scripts": {
     "prettier": "prettier '**/*.{js,ts}' --ignore-path ./.prettierignore",

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -529,7 +529,7 @@ describe('deliver', () => {
         });
         return Promise.resolve({
           // This is ignored since it's shadow traffic.
-          requestId: request.requestId,
+          requestId: 'uuid1',
           insertion: [
             toResponseInsertion('product1', 'uuid4', 0),
             toResponseInsertion('product2', 'uuid5', 1),
@@ -1836,7 +1836,10 @@ describe('shadow requests', () => {
       };
       deliveryClient = jest.fn((request) => {
         expect(request).toEqual(expectedDeliveryReq);
-        return Promise.resolve({});
+        return Promise.resolve({
+          requestId: 'uuid1',
+          insertion: [],
+        });
       });
     }
 


### PR DESCRIPTION
Contains some changes to other methods that don't use `field = (args) => {`.  This reduces the chance of a bad binding edge case.

TESTING=the unit tests broke.