### PR TITLE
refactor: rename to `retrievalInsertionOffset`

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -187,7 +187,7 @@ describe('no-op', () => {
           ...expectedRequest(),
           insertion: toRequestInsertions(products3()),
         },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       });
 
       const expectedRespInsertions = [
@@ -212,7 +212,7 @@ describe('no-op', () => {
           ...request(),
           insertion: [],
         },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       });
 
       expect(response.responseInsertions).toEqual([]);
@@ -235,7 +235,7 @@ describe('no-op', () => {
             size: 1,
           },
         },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       });
 
       const expectedRespInsertions = [{ contentId: 'product3', position: 0 }];
@@ -266,7 +266,7 @@ describe('deliver', () => {
 
     const response = await promotedClient.deliver({
       request: request(),
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(1);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -307,7 +307,7 @@ describe('deliver', () => {
 
     const response = await promotedClient.deliver({
       request: request(),
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(1);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -346,7 +346,7 @@ describe('deliver', () => {
         ...request(),
         insertion: [],
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(1);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -394,7 +394,7 @@ describe('deliver', () => {
         },
         insertion: [],
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(1);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -410,8 +410,8 @@ describe('deliver', () => {
     expect(metricsClient.mock.calls.length).toBe(0);
   });
 
-  // insertionStart is a fallback concept in the SDK.
-  it('insertionStart is ignored for Delivery API', async () => {
+  // retrievalInsertionOffset is a fallback concept in the SDK.
+  it('retrievalInsertionOffset is ignored for Delivery API', async () => {
     const deliveryClient = jest.fn((request) => {
       const expectedReq = expectedRequest();
       expectedReq.paging = { offset: 520, size: 10 };
@@ -433,7 +433,7 @@ describe('deliver', () => {
     req.paging = { offset: 520, size: 10 };
     const response = await promotedClient.deliver({
       request: req,
-      insertionStart: 500,
+      retrievalInsertionOffset: 500,
     });
     expect(deliveryClient.mock.calls.length).toBe(1);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -498,7 +498,7 @@ describe('deliver', () => {
           cohortId: 'HOLD_OUT',
           arm: 'CONTROL',
         },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       });
       expect(deliveryClient.mock.calls.length).toBe(0);
       expect(metricsClient.mock.calls.length).toBe(0);
@@ -583,7 +583,7 @@ describe('deliver', () => {
           cohortId: 'HOLD_OUT',
           arm: 'CONTROL',
         },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       });
       expect(deliveryClient.mock.calls.length).toBe(1);
       expect(metricsClient.mock.calls.length).toBe(0);
@@ -642,7 +642,7 @@ describe('deliver', () => {
           cohortId: 'HOLD_OUT',
           arm: 'TREATMENT',
         },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       });
       expect(deliveryClient.mock.calls.length).toBe(1);
       expect(metricsClient.mock.calls.length).toBe(0);
@@ -708,7 +708,7 @@ describe('deliver', () => {
           cohortId: 'HOLD_OUT',
           arm: 'TREATMENT',
         },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       });
       expect(deliveryClient.mock.calls.length).toBe(1);
       expect(metricsClient.mock.calls.length).toBe(0);
@@ -783,7 +783,7 @@ describe('deliver', () => {
         cohortId: 'HOLD_OUT',
         arm: 'CONTROL',
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(0);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -841,7 +841,7 @@ describe('deliver', () => {
         ...request(),
         insertion: toRequestInsertions(products3()),
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(0);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -913,7 +913,7 @@ describe('deliver', () => {
         cohortId: 'HOLD_OUT',
         arm: 'CONTROL',
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(0);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -955,7 +955,7 @@ describe('deliver', () => {
 
     const response = await promotedClient.deliver({
       request: request(),
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(1);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -1032,7 +1032,7 @@ describe('deliver', () => {
         cohortId: 'HOLD_OUT',
         arm: 'TREATMENT',
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(1);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -1110,7 +1110,7 @@ describe('deliver', () => {
           cohortId: 'HOLD_OUT',
           arm: 'TREATMENT',
         },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       });
       expect(deliveryClient.mock.calls.length).toBe(1);
       expect(metricsClient.mock.calls.length).toBe(0);
@@ -1192,7 +1192,7 @@ describe('deliver', () => {
           cohortId: 'HOLD_OUT',
           arm: 'TREATMENT',
         },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       };
       const response = await promotedClient.deliver(deliveryReq);
       expect(deliveryClient.mock.calls.length).toBe(1);
@@ -1260,7 +1260,7 @@ describe('deliver', () => {
       const response = await promotedClient.deliver({
         onlyLog: true,
         request: request(),
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       });
       expect(deliveryClient.mock.calls.length).toBe(1);
       expect(metricsClient.mock.calls.length).toBe(0);
@@ -1289,7 +1289,7 @@ describe('deliver', () => {
             ...expectedRequest(),
             requestId: 'uuid0',
           },
-          insertionStart: 0,
+          retrievalInsertionOffset: 0,
         })
       ).rejects.toEqual(new Error('Request.requestId should not be set'));
     });
@@ -1309,7 +1309,7 @@ describe('deliver', () => {
               toRequestInsertion(newProduct('1')),
             ],
           },
-          insertionStart: 0,
+          retrievalInsertionOffset: 0,
         })
       ).rejects.toEqual(new Error('Insertion.requestId should not be set'));
     });
@@ -1329,7 +1329,7 @@ describe('deliver', () => {
               toRequestInsertion(newProduct('1')),
             ],
           },
-          insertionStart: 0,
+          retrievalInsertionOffset: 0,
         })
       ).rejects.toEqual(new Error('Insertion.insertionId should not be set'));
     });
@@ -1342,7 +1342,7 @@ describe('deliver', () => {
             ...request(),
             insertion: [{}, toRequestInsertion(newProduct('2')), toRequestInsertion(newProduct('1'))],
           },
-          insertionStart: 0,
+          retrievalInsertionOffset: 0,
         })
       ).rejects.toEqual(new Error('Insertion.contentId should be set'));
     });
@@ -1355,7 +1355,7 @@ describe('deliver', () => {
           experiment: {
             platformId: 1,
           },
-          insertionStart: 0,
+          retrievalInsertionOffset: 0,
         })
       ).rejects.toEqual(new Error('Experiment.platformId should not be set'));
     });
@@ -1368,7 +1368,7 @@ describe('deliver', () => {
           experiment: {
             userInfo: {},
           },
-          insertionStart: 0,
+          retrievalInsertionOffset: 0,
         })
       ).rejects.toEqual(new Error('Experiment.userInfo should not be set'));
     });
@@ -1381,7 +1381,7 @@ describe('deliver', () => {
           experiment: {
             timing: {},
           },
-          insertionStart: 0,
+          retrievalInsertionOffset: 0,
         })
       ).rejects.toEqual(new Error('Experiment.timing should not be set'));
     });
@@ -1446,7 +1446,7 @@ describe('deliver with onlyLog=true', () => {
     const response = await promotedClient.deliver({
       onlyLog: true,
       request: request(),
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(0);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -1501,7 +1501,7 @@ describe('deliver with onlyLog=true', () => {
         ...request(),
         insertion: [],
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(0);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -1564,7 +1564,7 @@ describe('deliver with onlyLog=true', () => {
         },
         insertion: [],
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(0);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -1622,7 +1622,7 @@ describe('deliver with onlyLog=true', () => {
           size: 1,
         },
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(0);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -1683,7 +1683,7 @@ describe('deliver with onlyLog=true', () => {
           offset: 100,
         },
       },
-      insertionStart: 100,
+      retrievalInsertionOffset: 100,
     });
     expect(response.responseInsertions).toEqual([toResponseInsertion('product3', 'uuid2', 100)]);
 
@@ -1737,7 +1737,7 @@ describe('deliver with onlyLog=true', () => {
           offset: 1,
         },
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(0);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -1794,7 +1794,7 @@ describe('deliver with onlyLog=true', () => {
         sessionId: 'uuid10',
         viewId: 'uuid11',
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     expect(deliveryClient.mock.calls.length).toBe(0);
     expect(metricsClient.mock.calls.length).toBe(0);
@@ -1890,7 +1890,7 @@ describe('shadow requests', () => {
         ...request(),
         insertion: toRequestInsertions(products),
       },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     };
     const response = await promotedClient.deliver(deliveryRequest);
     const deliveryCallCount = shouldCallDelivery ? 1 : 0;
@@ -1952,7 +1952,7 @@ describe('noop promoted client', () => {
     const client = new NoopPromotedClient();
     const resp = client.deliver({
       request: request(),
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     const logReq = (await resp).logRequest;
     expect(logReq).toBeUndefined();
@@ -1960,7 +1960,7 @@ describe('noop promoted client', () => {
     const resp2 = client.deliver({
       onlyLog: true,
       request: request(),
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     });
     const logReq2 = (await resp2).logRequest;
     expect(logReq2).toBeUndefined();

--- a/src/client.ts
+++ b/src/client.ts
@@ -98,7 +98,7 @@ export class NoopPromotedClient implements PromotedClient {
     const { request } = deliveryRequest;
     const responseInsertions = this.pager.applyPaging(
       request.insertion ?? [],
-      deliveryRequest.insertionStart,
+      deliveryRequest.retrievalInsertionOffset,
       request?.paging
     );
     return Promise.resolve({
@@ -260,7 +260,11 @@ export class PromotedClientImpl implements PromotedClient {
       // If we did not call the API for any reason, apply the expected
       // paging to the full insertions here.
       // If you update this, update the no-op version too.
-      responseInsertions = this.pager.applyPaging(request.insertion, deliveryRequest.insertionStart, request.paging);
+      responseInsertions = this.pager.applyPaging(
+        request.insertion,
+        deliveryRequest.retrievalInsertionOffset,
+        request.paging
+      );
       addInsertionIds(responseInsertions, this.uuid);
       const responseToLog = {
         requestId,

--- a/src/delivery-request.ts
+++ b/src/delivery-request.ts
@@ -12,7 +12,7 @@ export interface DeliveryRequest {
 
   /**
    * Clients can send a subset of all request insertions to Promoted on
-   * `request.insertion`.  The `insertionStart` specifies the start index of
+   * `request.insertion`.  The `retrievalInsertionOffset` specifies the start index of
    * the array `request.insertion` in the list of all request insertions.
    *
    * `request.paging.offset` should be set to the zero-based position in all
@@ -20,21 +20,21 @@ export interface DeliveryRequest {
    *
    * Examples:
    * a. If there are 10 items and all 10 items are in `request.insertion`, then
-   *    insertionStart=0.
+   *    retrievalInsertionOffset=0.
    * b. If there are 10,000 items and the first 500 items are on `request.insertion`,
-   *    then insertionStart=0.
+   *    then retrievalInsertionOffset=0.
    * c. If there are 10,000 items and we want to send items [500,1000) on
-   *    `request.insertion`, then insertionStart=500.
+   *    `request.insertion`, then retrievalInsertionOffset=500.
    * d. If there are 10,000 items and we want to send the last page [9500,10000)
-   *    on `request.insertion`, then insertionStart=9500.
+   *    on `request.insertion`, then retrievalInsertionOffset=9500.
    *
    * This field is required because an incorrect value could result in a bad bug.
-   * If you only send the first X request insertions, then insertionStart=0.
+   * If you only send the first X request insertions, then retrievalInsertionOffset=0.
    *
    * If you are only sending the first X insertions to Promoted, you can set
-   * insertionStart=0.
+   * retrievalInsertionOffset=0.
    *
-   * For now, Promoted requires that `insertionStart <= paging.offset`.
+   * For now, Promoted requires that `retrievalInsertionOffset <= paging.offset`.
    * This will reduce the chance of errors and allow the SDK to fallback to
    *
    * Promoted recommends that the block size is a multiple of the page size.
@@ -43,7 +43,7 @@ export interface DeliveryRequest {
    * Follow this link for more details.
    * https://docs.promoted.ai/docs/ranking-requests#sending-even-more-request-insertions
    */
-  insertionStart: number;
+  retrievalInsertionOffset: number;
 
   /**
    * A way to customize when `deliver` should not run an experiment and just log

--- a/src/pager.test.ts
+++ b/src/pager.test.ts
@@ -20,7 +20,7 @@ describe('apply paging', () => {
     ];
   });
 
-  it('pages a window with insertionStart=0', () => {
+  it('pages a window with retrievalInsertionOffset=0', () => {
     const paging: Paging = {
       size: 2,
       offset: 1,
@@ -54,9 +54,9 @@ describe('apply paging', () => {
     expect(resIns[1].position).toEqual(2);
   });
 
-  describe('pages a window when insertionStart != 0', () => {
-    it('offset - insertionStart = 0', () => {
-      const insertionStart = 5;
+  describe('pages a window when retrievalInsertionOffset != 0', () => {
+    it('offset - retrievalInsertionOffset = 0', () => {
+      const retrievalInsertionOffset = 5;
       // This is a different block of request insertions (starting at 5).
       insertions = [
         {
@@ -74,7 +74,7 @@ describe('apply paging', () => {
         size: 2,
         offset: 5,
       };
-      const resIns = pager.applyPaging(insertions, insertionStart, paging);
+      const resIns = pager.applyPaging(insertions, retrievalInsertionOffset, paging);
       expect(resIns.length).toEqual(insertions.length - 1);
 
       // We take a page size of 2 starting at the beginning since prepaged.
@@ -86,8 +86,8 @@ describe('apply paging', () => {
       expect(resIns[1].position).toEqual(6);
     });
 
-    it('offset - insertionStart = 1', () => {
-      const insertionStart = 5;
+    it('offset - retrievalInsertionOffset = 1', () => {
+      const retrievalInsertionOffset = 5;
       // This is a different block of request insertions (starting at 5).
       insertions = [
         {
@@ -105,7 +105,7 @@ describe('apply paging', () => {
         size: 2,
         offset: 6,
       };
-      const resIns = pager.applyPaging(insertions, insertionStart, paging);
+      const resIns = pager.applyPaging(insertions, retrievalInsertionOffset, paging);
       expect(resIns.length).toEqual(insertions.length - 1);
 
       // We take a page size of 2 starting at the beginning since prepaged.
@@ -118,7 +118,7 @@ describe('apply paging', () => {
     });
 
     it('offset outside of size', () => {
-      const insertionStart = 5;
+      const retrievalInsertionOffset = 5;
       // This is a different block of request insertions (starting at 5).
       insertions = [
         {
@@ -136,7 +136,7 @@ describe('apply paging', () => {
         size: 2,
         offset: 8,
       };
-      const resIns = pager.applyPaging(insertions, insertionStart, paging);
+      const resIns = pager.applyPaging(insertions, retrievalInsertionOffset, paging);
       expect(resIns.length).toEqual(0);
     });
   });
@@ -165,12 +165,12 @@ describe('apply paging', () => {
     expect(resIns[2].position).toEqual(102);
   });
 
-  it('handles empty input for insertionStart=0', () => {
+  it('handles empty input for retrievalInsertionOffset=0', () => {
     const resIns = pager.applyPaging([], 0);
     expect(resIns.length).toEqual(0);
   });
 
-  it('handles empty input for insertionStart != 0', () => {
+  it('handles empty input for retrievalInsertionOffset != 0', () => {
     const paging: Paging = {
       size: 0,
       offset: 1,

--- a/src/pager.ts
+++ b/src/pager.ts
@@ -17,15 +17,15 @@ export class Pager {
    * Sets the position field on each assertion based on paging parameters and takes
    * a page of request insertions (if necessary).
    * @param requestInsertions the request insertions
-   * @param requestInsertionStart in the global set of all request insertions, how
+   * @param retrievalInsertionStart in the global set of all request insertions, how
    *                              far down is the subset of requestInsertions
    * @param paging paging info, may be nil
    * @returns the modified page of insertions
    */
-  applyPaging = (requestInsertions: Insertion[], requestInsertionStart: number, paging?: Paging): Insertion[] => {
+  applyPaging = (requestInsertions: Insertion[], retrievalInsertionStart: number, paging?: Paging): Insertion[] => {
     let offset = getOffset(paging);
     // validator.ts makes sure that index is positive.
-    let index = offset - requestInsertionStart;
+    let index = offset - retrievalInsertionStart;
     const size = getSize(paging, requestInsertions);
 
     const finalInsertionSize = Math.min(size, requestInsertions.length - index);

--- a/src/pager.ts
+++ b/src/pager.ts
@@ -17,15 +17,15 @@ export class Pager {
    * Sets the position field on each assertion based on paging parameters and takes
    * a page of request insertions (if necessary).
    * @param requestInsertions the request insertions
-   * @param retrievalInsertionStart in the global set of all request insertions, how
+   * @param retrievalInsertionOffset in the global set of all request insertions, how
    *                              far down is the subset of requestInsertions
    * @param paging paging info, may be nil
    * @returns the modified page of insertions
    */
-  applyPaging = (requestInsertions: Insertion[], retrievalInsertionStart: number, paging?: Paging): Insertion[] => {
+  applyPaging = (requestInsertions: Insertion[], retrievalInsertionOffset: number, paging?: Paging): Insertion[] => {
     let offset = getOffset(paging);
     // validator.ts makes sure that index is positive.
-    let index = offset - retrievalInsertionStart;
+    let index = offset - retrievalInsertionOffset;
     const size = getSize(paging, requestInsertions);
 
     const finalInsertionSize = Math.min(size, requestInsertions.length - index);

--- a/src/validator.test.ts
+++ b/src/validator.test.ts
@@ -6,7 +6,7 @@ describe('validator', () => {
     const v = new Validator({});
     const req: DeliveryRequest = {
       request: { requestId: 'aaa', userInfo: { anonUserId: 'aaa' } },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     };
 
     const errors = v.validate(req);
@@ -18,7 +18,7 @@ describe('validator', () => {
     const v = new Validator({});
     const req: DeliveryRequest = {
       request: { insertion: [{ requestId: 'a', contentId: 'zzz' }], userInfo: { anonUserId: 'aaa' } },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     };
 
     const errors = v.validate(req);
@@ -30,7 +30,7 @@ describe('validator', () => {
     const v = new Validator({});
     const req: DeliveryRequest = {
       request: { insertion: [{ insertionId: 'a', contentId: 'zzz' }], userInfo: { anonUserId: 'aaa' } },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     };
 
     const errors = v.validate(req);
@@ -42,7 +42,7 @@ describe('validator', () => {
     const v = new Validator({});
     const req: DeliveryRequest = {
       request: { insertion: [{ contentId: '' }], userInfo: { anonUserId: 'aaa' } },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     };
 
     const errors = v.validate(req);
@@ -54,7 +54,7 @@ describe('validator', () => {
     const v = new Validator({});
     const req: DeliveryRequest = {
       request: { insertion: [{ contentId: 'aaa' }], userInfo: { anonUserId: 'aaa' } },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     };
 
     const errors = v.validate(req);
@@ -65,7 +65,7 @@ describe('validator', () => {
     const v = new Validator({});
     const req: DeliveryRequest = {
       request: { insertion: [{ contentId: 'aaa' }], userInfo: { anonUserId: 'aaa' } },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
       experiment: { platformId: 9 },
     };
 
@@ -78,7 +78,7 @@ describe('validator', () => {
     const v = new Validator({});
     const req: DeliveryRequest = {
       request: { insertion: [{ contentId: 'aaa' }], userInfo: { anonUserId: 'aaa' } },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
       experiment: { userInfo: { userId: 'aaa' } },
     };
 
@@ -91,7 +91,7 @@ describe('validator', () => {
     const v = new Validator({});
     const req: DeliveryRequest = {
       request: { insertion: [{ contentId: 'aaa' }], userInfo: { anonUserId: 'aaa' } },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
       experiment: { timing: { clientLogTimestamp: 333 } },
     };
 
@@ -104,7 +104,7 @@ describe('validator', () => {
     const v = new Validator({});
     const req: DeliveryRequest = {
       request: { insertion: [{ contentId: 'aaa' }], userInfo: { anonUserId: 'aaa' } },
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
       experiment: { arm: 'TREATMENT', cohortId: 'aaa' },
     };
 
@@ -116,7 +116,7 @@ describe('validator', () => {
     const v = new Validator({});
     const req: DeliveryRequest = {
       request: {},
-      insertionStart: 0,
+      retrievalInsertionOffset: 0,
     };
 
     const errors = v.validate(req);
@@ -129,7 +129,7 @@ describe('validator', () => {
       const v = new Validator({});
       const req: DeliveryRequest = {
         request: { userInfo: { userId: 'aaa' } },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       };
 
       const errors = v.validate(req);
@@ -141,7 +141,7 @@ describe('validator', () => {
       const v = new Validator({ validateAnonUserIdSet: true });
       const req: DeliveryRequest = {
         request: { userInfo: { userId: 'aaa' } },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       };
 
       const errors = v.validate(req);
@@ -153,7 +153,7 @@ describe('validator', () => {
       const v = new Validator({ validateAnonUserIdSet: false });
       const req: DeliveryRequest = {
         request: { userInfo: { userId: 'aaa' } },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       };
 
       const errors = v.validate(req);
@@ -162,7 +162,7 @@ describe('validator', () => {
   });
 
   describe('paging', () => {
-    it('success with offset >= insertionStart', () => {
+    it('success with offset >= retrievalInsertionOffset', () => {
       const v = new Validator({});
       const req: DeliveryRequest = {
         request: {
@@ -172,14 +172,14 @@ describe('validator', () => {
             size: 100,
           },
         },
-        insertionStart: 0,
+        retrievalInsertionOffset: 0,
       };
 
       const errors = v.validate(req);
       expect(errors.length).toEqual(0);
     });
 
-    it('errors with offset < insertionStart', () => {
+    it('errors with offset < retrievalInsertionOffset', () => {
       const v = new Validator({});
       const req: DeliveryRequest = {
         request: {
@@ -189,13 +189,13 @@ describe('validator', () => {
             size: 100,
           },
         },
-        insertionStart: 10,
+        retrievalInsertionOffset: 10,
       };
 
       const errors = v.validate(req);
       expect(errors.length).toEqual(1);
       expect(errors[0].message).toEqual(
-        'offset(0) should be >= insertionStart(10).  offset should be the global position.'
+        'offset(0) should be >= retrievalInsertionOffset(10).  offset should be the global position.'
       );
     });
   });

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -76,14 +76,14 @@ export class Validator {
 
 const validatePaging = (deliveryRequest: DeliveryRequest): Error | undefined => {
   const {
-    insertionStart,
+    retrievalInsertionOffset,
     request: { paging },
   } = deliveryRequest;
 
   const offset = getOffset(paging);
-  if (offset < insertionStart) {
+  if (offset < retrievalInsertionOffset) {
     return new Error(
-      `offset(${offset}) should be >= insertionStart(${insertionStart}).  offset should be the global position.`
+      `offset(${offset}) should be >= retrievalInsertionOffset(${retrievalInsertionOffset}).  offset should be the global position.`
     );
   }
   return undefined;


### PR DESCRIPTION
BREAKING CHANGE: This changes the external interface.

TESTING=Ran existing unit tests.